### PR TITLE
Add macOS dark mode support

### DIFF
--- a/src/main/java/digital/slovensko/autogram/ui/gui/GUIApp.java
+++ b/src/main/java/digital/slovensko/autogram/ui/gui/GUIApp.java
@@ -27,7 +27,19 @@ public class GUIApp extends Application {
             var userSettings = UserSettings.load();
 
             Platform.setImplicitExit(false);
-            setUserAgentStylesheet(getClass().getResource("idsk.css").toExternalForm());
+
+            var osName = System.getProperty("os.name", "");
+            var dark = false;
+            if (osName.startsWith("Mac")) {
+                var interfaceStyle = System.getenv("AppleInterfaceStyle");
+                dark = interfaceStyle != null && interfaceStyle.equalsIgnoreCase("Dark");
+            }
+
+            if (dark) {
+                setUserAgentStylesheet(getClass().getResource("idsk-dark.css").toExternalForm());
+            } else {
+                setUserAgentStylesheet(getClass().getResource("idsk.css").toExternalForm());
+            }
             var titleString = "Autogram";
 
             autogram = new Autogram(new GUI(getHostServices(), userSettings), userSettings);

--- a/src/main/resources/digital/slovensko/autogram/ui/gui/idsk-dark.css
+++ b/src/main/resources/digital/slovensko/autogram/ui/gui/idsk-dark.css
@@ -1,0 +1,38 @@
+@import url("idsk.css");
+
+.root {
+  -autogram-text-colour: #ffffff;
+  -autogram-secondary-text-colour: #cccccc;
+
+  -autogram-link-colour: #5fa8ff;
+  -autogram-link-hover-colour: #79b6ff;
+
+  -autogram-border-colour: #888888;
+  -autogram-input-border-colour: #dddddd;
+  -autogram-input-background-color: #2b2b2b;
+
+  -autogram-success-colour: #4caf50;
+  -autogram-priamry-button-hover-colour: #3e8e41;
+
+  -autogram-secondary-hover-colour: #383838;
+
+  -autogram-warning-button-colour: #e06f6f;
+  -autorgam-warning-button-hover-colour: #c05050;
+
+  -autogram-background-colour: #1e1e1e;
+  -autogram-secondary-background-colour: #2c2c2c;
+
+  -autogram-focus-colour: #ffdd00;
+  -autogram-focus-text-colour: #0b0c0c;
+
+  -autogram-error-colour: #ff6f6f;
+
+  -autogram-partial-success-colour: #6792ff;
+
+  -fx-font-family: "Source Sans Pro", "Arial", sans-serif;
+  -fx-font-size: 16px;
+
+  -fx-font-smoothing-type: gray;
+
+  -autogram-warning-color: #ffdf0f;
+}

--- a/src/main/scripts/resources/Info.plist.template
+++ b/src/main/scripts/resources/Info.plist.template
@@ -44,6 +44,8 @@
   </array>DEPLOY_FILE_ASSOCIATIONS
   <key>NSHighResolutionCapable</key>
   <string>true</string>
+  <key>NSRequiresAquaSystemAppearance</key>
+  <false/>
   <key>NSMicrophoneUsageDescription</key>
   <string>The application DEPLOY_LAUNCHER_NAME is requesting access to the microphone.</string>
  </dict>


### PR DESCRIPTION
## Summary
- allow macOS to ignore Aqua system appearance
- provide a dark color stylesheet
- switch stylesheets based on macOS dark appearance

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d0b3c80688320afcac3cc41aba52c