### PR TITLE
Add universal macOS packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -518,6 +518,20 @@
         </profile>
 
         <profile>
+            <id>macos-universal</id>
+            <activation>
+                <os>
+                    <name>Mac OS X</name>
+                    <family>unix</family>
+                </os>
+            </activation>
+            <properties>
+                <platform>mac-universal</platform>
+                <crypto.modules>jdk.crypto.cryptoki</crypto.modules>
+            </properties>
+        </profile>
+
+        <profile>
             <id>github_authenticated</id>
             <activation>
                 <property>


### PR DESCRIPTION
## Summary
- allow packaging script to create universal macOS pkg
- add macos-universal profile to Maven

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d1d6c8af08320bddcba8f44b94452