### PR TITLE
Verify keychain after decoding

### DIFF
--- a/.github/workflows/macos-main-package.yaml
+++ b/.github/workflows/macos-main-package.yaml
@@ -44,6 +44,18 @@ jobs:
           security list-keychain -d user -s $APPLE_KEYCHAIN_PATH
           security default-keychain -s $APPLE_KEYCHAIN_PATH
 
+      - name: Verify Apple keychain
+        shell: bash
+        run: |
+          if ! ls -l "$APPLE_KEYCHAIN_PATH"; then
+            echo "Invalid keychain: cannot find file" >&2
+            exit 1
+          fi
+          if ! security show-keychain-info "$APPLE_KEYCHAIN_PATH" >/dev/null; then
+            echo "Invalid keychain: could not read info" >&2
+            exit 1
+          fi
+
       - name: Package with Maven
         run: ./mvnw -B -C -V package -P system-jdk
         env:


### PR DESCRIPTION
## Summary
- verify the Apple keychain after it is decoded

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d1d6a13108320b4eb82f7b3084de6