### PR TITLE
Fix packaging script option

### DIFF
--- a/src/main/scripts/package.sh
+++ b/src/main/scripts/package.sh
@@ -196,10 +196,12 @@ if [[ "${platform}" == "mac-universal" ]]; then
         )
     fi
 
+    # jpackage 24 no longer supports the deprecated --target-arch option.
+    # Build each architecture separately using the host JDK.
     for arch in x64 aarch64; do
         destDir="${output}/${arch}"
         mkdir -p "${destDir}"
-        $jpackage "${baseArguments[@]}" "${signingArguments[@]}" --target-arch "${arch}" --dest "${destDir}"
+        $jpackage "${baseArguments[@]}" "${signingArguments[@]}" --dest "${destDir}"
         exitValue=$?
         rm -rf ./DTempFiles
         checkExitCode $exitValue


### PR DESCRIPTION
## Summary
- remove unsupported `--target-arch` flag in packaging script
- clarify in-script comment about building per architecture

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d3163f1648320b3f9abcaff0d52c1