### PR TITLE
Disable mac pkg signing

### DIFF
--- a/src/main/resources/digital/slovensko/autogram/build.properties
+++ b/src/main/resources/digital/slovensko/autogram/build.properties
@@ -60,7 +60,7 @@ mac.identifier=
 mac.name=Autogram
 # Request that the bundle be signed (1/0).
 # Defaults to 0.
-mac.sign=1
+mac.sign=0
 # Path of the keychain to search for the signing identity (absolute path or relative to the current directory).
 # Defaults to the standard keychains.
 # deprecated


### PR DESCRIPTION
## Summary
- stop signing macOS package by default

## Testing
- `./mvnw package -Dmaven.test.skip` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d4f2d4ff48320913bb61e3009c928