### PR TITLE
Disable mac pkg signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Running `./mvnw package` prepares everything in `./target`:
 - `autogram-*.jar` - JAR with the application
 
 Then using `jpackage`, it creates all executable packages (.msi/.exe, .dmg/.pkg, and .rpm/.deb).
+On macOS, jpackage signs the installer by default. To build an unsigned macOS package, set
+`mac.sign=0` in `src/main/resources/digital/slovensko/autogram/build.properties` before running
+`./mvnw package`.
 
 ```sh
 ./mvnw versions:set -DnewVersion=$(git describe --tags --abbrev=0 | sed -r 's/^v//g')

--- a/src/main/resources/digital/slovensko/autogram/build.properties
+++ b/src/main/resources/digital/slovensko/autogram/build.properties
@@ -60,7 +60,7 @@ mac.identifier=
 mac.name=Autogram
 # Request that the bundle be signed (1/0).
 # Defaults to 0.
-mac.sign=1
+mac.sign=0
 # Path of the keychain to search for the signing identity (absolute path or relative to the current directory).
 # Defaults to the standard keychains.
 # deprecated


### PR DESCRIPTION
## Summary
- stop signing macOS package by default
- add README note about unsigned macOS build

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686d4f2d4ff48320913bb61e3009c928