### PR TITLE
Update SK build docs about macOS signing

### DIFF
--- a/README-SK.md
+++ b/README-SK.md
@@ -83,6 +83,10 @@ Spustenie `./mvnw package` pripraví všetko do `./target`:
 
 Následne pomocou `jpackage` vytvorí všetky spustiteľné balíčky (.msi/.exe, .dmg/.pkg, a .rpm/.deb).
 
+Na macOS `jpackage` štandardne podpisuje inštalátor. Ak chcete vytvoriť nepodpísaný macOS balík, nastavte
+`mac.sign=0` v `src/main/resources/digital/slovensko/autogram/build.properties` pred spustením
+`./mvnw package`.
+
 ```sh
 ./mvnw versions:set -DnewVersion=$(git describe --tags --abbrev=0 | sed -r 's/^v//g')
 ./mvnw package


### PR DESCRIPTION
## Summary
- clarify that jpackage on macOS signs packages by default
- document setting `mac.sign=0` in `build.properties` to build without signing

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e4a03958c83209797553aa1de978e