### PR TITLE
Fix mac-universal jpackage arch

### DIFF
--- a/src/main/scripts/package.sh
+++ b/src/main/scripts/package.sh
@@ -197,11 +197,12 @@ if [[ "${platform}" == "mac-universal" ]]; then
     fi
 
     # jpackage 24 no longer supports the deprecated --target-arch option.
-    # Build each architecture separately using the host JDK.
+    # Build each architecture separately. Use --arch to explicitly set the
+    # target architecture so that both x64 and aarch64 images are produced.
     for arch in x64 aarch64; do
         destDir="${output}/${arch}"
         mkdir -p "${destDir}"
-        $jpackage "${baseArguments[@]}" "${signingArguments[@]}" --dest "${destDir}"
+        $jpackage "${baseArguments[@]}" "${signingArguments[@]}" --arch "${arch}" --dest "${destDir}"
         exitValue=$?
         rm -rf ./DTempFiles
         checkExitCode $exitValue


### PR DESCRIPTION
## Summary
- use `--arch` argument when building per-arch app-image

## Testing
- `./mvnw test -P system-jdk` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e4a05064c8320a7d7632061db4fab