### PR TITLE
Detect jpackage --arch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Running `./mvnw package` prepares everything in `./target`:
 - `autogram-*.jar` - JAR with the application
 
 Then using `jpackage`, it creates all executable packages (.msi/.exe, .dmg/.pkg, and .rpm/.deb).
+The packaging script automatically detects if `jpackage` supports the newer `--arch` option
+and falls back to `--target-arch` on older JDK versions.
 On macOS, jpackage signs the installer by default. To build an unsigned macOS package, set
 `mac.sign=0` in `src/main/resources/digital/slovensko/autogram/build.properties` before running
 `./mvnw package`.

--- a/src/main/scripts/package.sh
+++ b/src/main/scripts/package.sh
@@ -10,6 +10,12 @@ platform=${5}
 version=${6}
 output=${7}
 
+# Determine whether jpackage supports the new --arch parameter
+archOption="--target-arch"
+if "$jpackage" --help 2>&1 | grep -q -- '--arch'; then
+    archOption="--arch"
+fi
+
 function checkExitCode() {
     exitValue=${1}
     if [[ ${exitValue} -ne 0 ]]; then
@@ -203,7 +209,7 @@ if [[ "${platform}" == "mac-universal" ]]; then
     for arch in x64 aarch64; do
         destDir="${output}/${arch}"
         mkdir -p "${destDir}"
-        $jpackage "${baseArguments[@]}" "${signingArguments[@]}" --target-arch "${arch}" --dest "${destDir}"
+        $jpackage "${baseArguments[@]}" "${signingArguments[@]}" ${archOption} "${arch}" --dest "${destDir}"
         exitValue=$?
         rm -rf ./DTempFiles
         checkExitCode $exitValue


### PR DESCRIPTION
## Summary
- detect `--arch` support in `package.sh`
- use detected option when building mac-universal packages
- document the behavior in README

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686e5ff0a28483209a1cb9521c989b64