### PR TITLE
feat(macOS): add headless PDF signing Quick Action

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -6,38 +6,38 @@ Cieľ je prerobiť UI tak, aby pôsobilo natívne pre macOS, bolo čitateľné v
 Implementácia zostane v existujúcej JavaFX architektúre (single window + inline overlays), ale zjednotí sa dizajn systém, layout pravidlá, fokus/keyboard behavior a testovací runbook.
 
 ### Current Frontend Architecture (as-is)
-- App bootstrap: `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/java/digital/slovensko/autogram/ui/gui/GUIApp.java`
-- Main shell + overlays + panel switching: `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/java/digital/slovensko/autogram/ui/gui/MainMenuController.java`
-- Signing workflow screen: `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml` + `SigningDialogController`
-- Settings workflow: `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/settings-dialog.fxml` + `SettingsDialogController`
-- Theme system: `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/macos-native.css` + `macos-native-dark.css`
-- Overlay dialogs: inline host in `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/main-menu.fxml`
+- App bootstrap: `src/main/java/digital/slovensko/autogram/ui/gui/GUIApp.java`
+- Main shell + overlays + panel switching: `src/main/java/digital/slovensko/autogram/ui/gui/MainMenuController.java`
+- Signing workflow screen: `src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml` + `SigningDialogController`
+- Settings workflow: `src/main/resources/digital/slovensko/autogram/ui/gui/settings-dialog.fxml` + `SettingsDialogController`
+- Theme system: `src/main/resources/digital/slovensko/autogram/ui/gui/macos-native.css` + `macos-native-dark.css`
+- Overlay dialogs: inline host in `src/main/resources/digital/slovensko/autogram/ui/gui/main-menu.fxml`
 
 ### Priority Findings to Fix Before Visual Polish
-1. Duplicate `fx:id` bug in signing view: `fx:id="signaturesTable"` is duplicated in `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml`.  
-2. Undefined color token: `-autogram-accent` used but not defined in `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/macos-native.css`.  
-3. Overlay sizing conflict: static `maxWidth/maxHeight` in `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/main-menu.fxml` fights content-driven dialog sizing.  
+1. Duplicate `fx:id` bug in signing view: `fx:id="signaturesTable"` is duplicated in `src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml`.
+2. Undefined color token: `-autogram-accent` used but not defined in `src/main/resources/digital/slovensko/autogram/ui/gui/macos-native.css`.
+3. Overlay sizing conflict: static `maxWidth/maxHeight` in `src/main/resources/digital/slovensko/autogram/ui/gui/main-menu.fxml` fights content-driven dialog sizing.
 4. Dark-mode text leakage: dynamic `Text`/`Label` content in signature table and options can render low-contrast/black in signing area.  
 5. Settings tab icon fallback to square: current Region-shape approach is fragile in CSS parsing/fallback states.
 
 ### Implementation Plan (Decision Complete)
 
 ### Phase 1: Foundation and Safety (UI Stability Baseline)
-1. Remove duplicate `signaturesTable` node in `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml`.
+1. Remove duplicate `signaturesTable` node in `src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml`.
 2. Normalize overlay container sizing:
-- Remove hard `maxWidth/maxHeight` from `dialogContainer` in `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/main-menu.fxml`.
+- Remove hard `maxWidth/maxHeight` from `dialogContainer` in `src/main/resources/digital/slovensko/autogram/ui/gui/main-menu.fxml`.
 - Keep content-sized dialogs by default and enforce min/max per dialog class only.
-3. Keep existing focus logic in `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/java/digital/slovensko/autogram/ui/gui/PasswordController.java` and `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/java/digital/slovensko/autogram/ui/gui/MainMenuController.java`, then unify into one overlay focus utility method.
+3. Keep existing focus logic in `src/main/java/digital/slovensko/autogram/ui/gui/PasswordController.java` and `src/main/java/digital/slovensko/autogram/ui/gui/MainMenuController.java`, then unify into one overlay focus utility method.
 
 ### Phase 2: Design System v2 (Native macOS + Soft Glass)
-1. In `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/macos-native.css`:
+1. In `src/main/resources/digital/slovensko/autogram/ui/gui/macos-native.css`:
 - Define full token set for foreground/background/surface/border/focus states.
 - Add missing token definitions (`-autogram-accent` removed or replaced by `-autogram-focus-colour`).
 - Introduce fixed semantic tokens: `--surface-0/1/2`, `--text-primary/secondary/muted`, `--interactive-normal/hover/active/disabled`.
-2. In `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/macos-native-dark.css`:
+2. In `src/main/resources/digital/slovensko/autogram/ui/gui/macos-native-dark.css`:
 - Explicit dark overrides for all controls used in app: `ChoiceBox`, popup menu rows, `CheckBox`, `RadioButton`, table text, labels inside options/signature sections.
 - Guarantee WCAG-level readability for body and helper text.
-3. Replace fragile settings tab icon `Region` shapes with explicit `SVGPath` icons in `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/settings-dialog.fxml`.
+3. Replace fragile settings tab icon `Region` shapes with explicit `SVGPath` icons in `src/main/resources/digital/slovensko/autogram/ui/gui/settings-dialog.fxml`.
 
 ### Phase 3: Settings Panel Redesign (Compact, Aligned, Native)
 1. Keep four tabs, but redesign layout rules:
@@ -55,8 +55,8 @@ Implementácia zostane v existujúcej JavaFX architektúre (single window + inli
 - Align Reset left, Save right, with persistent sticky footer behavior.
 
 ### Phase 4: Signing Screen Readability and Workflow
-1. Ensure all signature summary text nodes get explicit style classes at source creation in `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/java/digital/slovensko/autogram/ui/gui/GUIValidationUtils.java`.
-2. Update signing options area (`Formát`, `Časová pečiatka`, CTA) in `/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml`:
+1. Ensure all signature summary text nodes get explicit style classes at source creation in `src/main/java/digital/slovensko/autogram/ui/gui/GUIValidationUtils.java`.
+2. Update signing options area (`Formát`, `Časová pečiatka`, CTA) in `src/main/resources/digital/slovensko/autogram/ui/gui/signing-dialog.fxml`:
 - Strong contrast labels.
 - Balanced spacing.
 - Compact CTA row.
@@ -77,12 +77,12 @@ Implementácia zostane v existujúcej JavaFX architektúre (single window + inli
 
 ### Phase 6: Run/Verify Workflow (Always Reproducible on macOS)
 1. Keep script-first QA entrypoint:
-- `/Users/Magneto/CascadeProjects/autogram-macOS/scripts/macos-update-check.sh`
+- `scripts/macos-update-check.sh`
 2. Add a dedicated UI smoke script (`scripts/macos-ui-smoke.sh`) that runs:
 - compile,
 - targeted tests,
 - launches app with dark mode note + checklist.
-3. Document exact manual verification protocol in `/Users/Magneto/CascadeProjects/autogram-macOS/DEVELOPER.md`:
+3. Document exact manual verification protocol in `DEVELOPER.md`:
 - dark mode checks,
 - modal focus checks,
 - settings dropdown visibility checks,
@@ -103,7 +103,7 @@ where `OverlaySpec` includes size preset, autofocus selector, and dismiss behavi
 ## Test Cases and Scenarios
 
 ### Automated
-1. Existing test suite green via `/Users/Magneto/CascadeProjects/autogram-macOS/scripts/macos-update-check.sh`.
+1. Existing test suite green via `scripts/macos-update-check.sh`.
 2. Add UI controller tests (headless where possible):
 - `PasswordController` autofocus behavior.
 - Overlay focus assignment from `MainMenuController`.

--- a/README-SK.md
+++ b/README-SK.md
@@ -178,6 +178,7 @@ Výsledné balíčky sa objavia v `packaging/output/`.
 - [PORTING.md](PORTING.md)
 - [PLAN.md](PLAN.md)
 - [UPSTREAM_SYNC_PR_CHECKLIST.md](UPSTREAM_SYNC_PR_CHECKLIST.md)
+- [macOS CLI a Finder Quick Action](docs/macos-cli-automation.md)
 
 ## Autori a Sponzori
 Jakub Ďuraš, Slovensko.Digital, CRYSTAL CONSULTING, s.r.o., Solver IT s.r.o. a ďalší spoluautori.

--- a/README-SK.md
+++ b/README-SK.md
@@ -123,6 +123,32 @@ Poznámky:
 - Ide o lokálny ad-hoc podpis, nie Apple notarizáciu.
 - Na verejnú distribúciu bez varovaní treba Apple Developer signing a notarizáciu.
 
+## Finder Quick Action pre CLI podpisovanie PDF
+
+Repozitár obsahuje macOS Quick Action vytvorenú v Automatore. Spúšťa sa vo Finderi cez pravé tlačidlo myši, menu **Quick Actions** a položku `Sign PDFs Autogram`. Nie je to workflow pre macOS Shortcuts.
+
+Quick Action podpíše jeden alebo viac označených PDF súborov cez Autogram CLI. Neotvára grafické rozhranie Autogramu ani okno Terminálu. Výber úložiska certifikátu, certifikátu a zadanie PIN-u prebieha cez macOS dialógy.
+
+### Požiadavky
+
+- macOS s Finderom a aplikáciou Automator.
+- Nainštalovaný Autogram s CLI, buď z release balíka, alebo zo zdrojového kódu.
+- Pripojený podpisový token alebo karta, príslušný PKCS#11 ovládač a PIN.
+- Sieťové pripojenie ku kvalifikovanej službe časových pečiatok pri podpise PAdES Baseline T.
+- Na Apple Silicon Rosetta a Intel build Autogramu, ak je používaný PKCS#11 ovládač iba pre Intel.
+
+Quick Action používa predvolene PAdES Baseline T a kvalifikovanú časovú pečiatku. Výstup uloží vedľa pôvodného súboru ako `<názov>_signed.pdf`, pričom pôvodný PDF nemení. Ak výstup už existuje, vytvorí očíslovanú alternatívu. Skripty v tomto repozitári neinštalujú Autogram ani ovládač tokenu.
+
+### Inštalácia Quick Action
+
+1. Otvor **Automator** a zvoľ **New Document > Quick Action**.
+2. Nastav **Workflow receives current** na `files or folders` a **In** na `Finder`.
+3. Pridaj akciu **Run Shell Script**, nastav shell `/bin/bash` a **Pass input** na `as arguments`.
+4. Vlož skript uvedený v anglickej časti [README](README.md) a nahraď cestu k repozitáru.
+5. Ulož akciu ako `Sign PDFs Autogram`.
+
+Potom označ jeden alebo viac PDF súborov vo Finderi, klikni pravým tlačidlom, otvor **Quick Actions** a vyber `Sign PDFs Autogram`. Podrobná konfigurácia, Apple Silicon, Rosetta, kvalifikované časové pečiatky a riešenie problémov sú v [dokumentácii macOS CLI a Finder Quick Action](docs/macos-cli-automation.md).
+
 ## Integrácia
 Swagger dokumentácia pre HTTP API je dostupná na [GitHube](https://generator3.swagger.io/index.html?url=https://raw.githubusercontent.com/slovensko-digital/autogram/main/src/main/resources/digital/slovensko/autogram/server/server.yml) alebo po spustení aplikácie na [http://localhost:37200/docs](http://localhost:37200/docs).
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,17 @@ Notes:
 
 ## Finder Quick Action: CLI PDF Signing
 
-This repository includes a macOS Finder Quick Action that signs one or more selected PDF files through the Autogram CLI. It opens macOS dialogs for the certificate store, signing certificate, and PIN, but it does not open the Autogram GUI or a Terminal window.
+This repository includes a macOS Finder Quick Action that signs one or more selected PDF files through the Autogram CLI. It is an Automator Quick Action available from Finder's right-click menu. It opens macOS dialogs for the certificate store, signing certificate, and PIN, but it does not open the Autogram GUI or a Terminal window. This is not a macOS Shortcuts workflow.
+
+### Requirements
+
+- macOS with Finder and Automator.
+- A CLI-capable Autogram application, installed from a release package or built locally.
+- The required signing token or card, its PKCS#11 driver, and the PIN.
+- Network access to the configured qualified timestamp service when using PAdES Baseline T.
+- On Apple Silicon, Rosetta and an Intel Autogram build when the installed PKCS#11 driver is Intel-only.
+
+The Quick Action runs the signing process in the background. Certificate store selection, certificate selection, and PIN entry are intentionally shown as macOS dialogs. The original PDFs are never overwritten. The scripts are integration files and do not install the Autogram application or the token driver.
 
 The default Quick Action configuration is:
 
@@ -124,7 +134,7 @@ On Apple Silicon, an Intel-only I.CA SecureStore PKCS#11 driver requires Rosetta
 
 ### Create the Finder Quick Action
 
-1. Open Automator and choose **New Document > Quick Action**.
+1. Open **Automator** and choose **New Document > Quick Action**. Do not create a macOS Shortcut for this integration.
 2. Set **Workflow receives current** to `files or folders` and **In** to `Finder`.
 3. Add the **Run Shell Script** action.
 4. Set **Shell** to `/bin/bash` and **Pass input** to `as arguments`.
@@ -137,7 +147,7 @@ REPO_DIR="/path/to/autogram-macOS"
 
 6. Save the Quick Action as `Sign PDFs Autogram`.
 
-Select one or more PDF files in Finder, right-click, open **Quick Actions**, and choose `Sign PDFs Autogram`. The original files are not overwritten. The signing process is CLI-based and the PIN is entered through a hidden macOS dialog.
+Select one or more PDF files in Finder, right-click, open **Quick Actions**, and choose `Sign PDFs Autogram`. The original files are not overwritten. The signing process is CLI-based and the PIN is entered through a hidden macOS dialog. Only PDF files are processed; if the selection contains no PDF files, the action reports that there is nothing to sign.
 
 For manual CLI use, run:
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,53 @@ Notes:
 - This is a local ad-hoc signature, not Apple notarization.
 - For public distribution without warnings, use Apple Developer signing and notarization.
 
+## Finder Quick Action: CLI PDF Signing
+
+This repository includes a macOS Finder Quick Action that signs one or more selected PDF files through the Autogram CLI. It opens macOS dialogs for the certificate store, signing certificate, and PIN, but it does not open the Autogram GUI or a Terminal window.
+
+The default Quick Action configuration is:
+
+- PAdES Baseline T for PDF files.
+- A timestamp request to `http://timestamp.sectigo.com/qualified`.
+- A new output beside each source file named `<name>_signed.pdf`. Existing outputs are preserved and numbered.
+
+### Install the scripts
+
+Clone the repository and make the macOS scripts executable:
+
+```sh
+git clone https://github.com/originalmagneto/autogram-macOS.git
+cd autogram-macOS
+chmod +x scripts/macos-automation/*.sh
+```
+
+On Apple Silicon, an Intel-only I.CA SecureStore PKCS#11 driver requires Rosetta and an Intel Autogram build. Place that application at `$HOME/Applications/Autogram Intel GUI.app`, or set `AUTOGRAM_INTEL_BIN` to the path of another Intel Autogram executable. The details and architecture checks are documented in [docs/macos-cli-automation.md](docs/macos-cli-automation.md).
+
+### Create the Finder Quick Action
+
+1. Open Automator and choose **New Document > Quick Action**.
+2. Set **Workflow receives current** to `files or folders` and **In** to `Finder`.
+3. Add the **Run Shell Script** action.
+4. Set **Shell** to `/bin/bash` and **Pass input** to `as arguments`.
+5. Use this script body, replacing the repository path with the location where you cloned it:
+
+```bash
+REPO_DIR="/path/to/autogram-macOS"
+"$REPO_DIR/scripts/macos-automation/autogram-quick-action.sh" "$@"
+```
+
+6. Save the Quick Action as `Sign PDFs Autogram`.
+
+Select one or more PDF files in Finder, right-click, open **Quick Actions**, and choose `Sign PDFs Autogram`. The original files are not overwritten. The signing process is CLI-based and the PIN is entered through a hidden macOS dialog.
+
+For manual CLI use, run:
+
+```sh
+scripts/macos-automation/autogram-cli-sign.sh --driver secure_store "/path/to/file.pdf"
+```
+
+The CLI also supports `--list-keys`, `--key`, `--pin-stdin`, `--pdf-level`, `--tsa-server`, and batch directory signing. Do not put a PIN in shell history or commit it to a script. For troubleshooting and the full verification checklist, see [docs/macos-cli-automation.md](docs/macos-cli-automation.md).
+
 ## Integration
 Swagger documentation for the HTTP API is available on [GitHub](https://generator3.swagger.io/index.html?url=https://raw.githubusercontent.com/slovensko-digital/autogram/main/src/main/resources/digital/slovensko/autogram/server/server.yml) or after launching the app at [http://localhost:37200/docs](http://localhost:37200/docs).
 
@@ -155,6 +202,7 @@ Resulting packages appear in `packaging/output/`.
 - [PORTING.md](PORTING.md)
 - [PLAN.md](PLAN.md)
 - [UPSTREAM_SYNC_PR_CHECKLIST.md](UPSTREAM_SYNC_PR_CHECKLIST.md)
+- [macOS CLI and Finder Quick Action](docs/macos-cli-automation.md)
 
 ## Authors and Sponsors
 Jakub Duras, Slovensko.Digital, CRYSTAL CONSULTING, s.r.o., Solver IT s.r.o., and other contributors.

--- a/docs/macos-cli-automation.md
+++ b/docs/macos-cli-automation.md
@@ -1,12 +1,22 @@
 # Autogram CLI Automation on macOS
 
-Autogram supports CLI mode via `--cli` and can be automated from Finder/Quick Actions.
+Autogram supports CLI mode via `--cli` and can be automated from Finder through an Automator Quick Action. This document describes the macOS integration in this fork. It is not a macOS Shortcuts workflow.
 
 ## What was prepared
 
 - `scripts/macos-automation/autogram-cli-sign.sh`
 - `scripts/macos-automation/autogram-quick-action.sh`
 - `scripts/macos-automation/autogram-finder-selection.sh`
+
+## Requirements
+
+- macOS with Finder and Automator.
+- A CLI-capable Autogram application. The scripts do not install Autogram.
+- The signing token or card, its PKCS#11 driver, and the PIN.
+- Network access to the qualified timestamp service when PAdES Baseline T is required.
+- Rosetta and an Intel Autogram build on Apple Silicon when the PKCS#11 driver is Intel-only.
+
+The Quick Action does not open the Autogram GUI or a Terminal window. It uses macOS dialogs for certificate store selection, certificate selection, and PIN entry, then runs the CLI in the background.
 
 ## 1) Make scripts executable
 
@@ -31,7 +41,7 @@ REPO_DIR="/path/to/autogram-macOS"
 "$REPO_DIR/scripts/macos-automation/autogram-quick-action.sh" "$@"
 ```
 
-When triggered, it uses macOS dialogs for the certificate store, certificate and PIN, then runs Autogram CLI in the background. No Autogram window or Terminal window is opened.
+When triggered from Finder, it uses macOS dialogs for the certificate store, certificate and PIN, then runs Autogram CLI in the background. No Autogram window or Terminal window is opened. Select one or more PDF files in Finder to process them as a batch.
 
 The Quick Action always configures:
 

--- a/docs/macos-cli-automation.md
+++ b/docs/macos-cli-automation.md
@@ -1,0 +1,144 @@
+# Autogram CLI Automation on macOS
+
+Autogram supports CLI mode via `--cli` and can be automated from Finder/Quick Actions.
+
+## What was prepared
+
+- `scripts/macos-automation/autogram-cli-sign.sh`
+- `scripts/macos-automation/autogram-quick-action.sh`
+- `scripts/macos-automation/autogram-finder-selection.sh`
+
+## 1) Make scripts executable
+
+```bash
+chmod +x scripts/macos-automation/*.sh
+```
+
+## 2) Quick Action (right click in Finder)
+
+1. Open Automator and create a new **Quick Action**.
+2. Set:
+   - Workflow receives current: `files or folders`
+   - In: `Finder`
+3. Add **Run Shell Script** action.
+4. Set:
+   - Shell: `/bin/bash`
+   - Pass input: `as arguments`
+5. Script body:
+
+```bash
+REPO_DIR="/path/to/autogram-macOS"
+"$REPO_DIR/scripts/macos-automation/autogram-quick-action.sh" "$@"
+```
+
+When triggered, it uses macOS dialogs for the certificate store, certificate and PIN, then runs Autogram CLI in the background. No Autogram window or Terminal window is opened.
+
+The Quick Action always configures:
+
+- PAdES for PDF files.
+- A qualified timestamp from `http://timestamp.sectigo.com/qualified`.
+- The selected certificate storage.
+
+When multiple PDF files are selected, the same CLI configuration is applied to each file. After signing, each result is saved beside the original as `<name>_signed.pdf`, with numbered variants if that filename already exists.
+
+## 3) Finder automation (current selection)
+
+Run this script whenever Finder already has items selected:
+
+```bash
+REPO_DIR="/path/to/autogram-macOS"
+"$REPO_DIR/scripts/macos-automation/autogram-finder-selection.sh"
+```
+
+You can bind it in your preferred launcher (Shortcuts, Alfred, Raycast, etc.).
+
+## Notes
+
+- Default binary lookup:
+  - `/Applications/Autogram.app/Contents/MacOS/AutogramApp`
+  - `$HOME/Applications/Autogram.app/Contents/MacOS/AutogramApp`
+  - local build: `target/app-image/Autogram.app/Contents/MacOS/AutogramApp`
+- Override binary location with `AUTOGRAM_BIN=/custom/path/AutogramApp`.
+- On Apple Silicon, the I.CA SecureStore 8.1 driver currently installed on this Mac is Intel-only. The launcher detects this and uses an Intel Autogram build through Rosetta when available.
+- Put the Intel GUI build at `$HOME/Applications/Autogram Intel GUI.app`. The Quick Action also recognizes `$HOME/Applications/Autogram Intel.app` and `/Applications/Autogram Intel.app`.
+- For the manual CLI script, set `AUTOGRAM_INTEL_BIN=/custom/path/Intel/AutogramApp` when needed.
+- The official Autogram release publishes separate `macos.pkg` and `macos-intel.pkg` packages. The Intel package is required for an Intel-only PKCS#11 driver.
+- `autogram-cli-sign.sh` remains available for manual CLI use and may ask for driver, key, PIN or password in Terminal.
+- The Finder Quick Action uses `autogram-quick-action.sh`, which drives the CLI path without opening a terminal.
+- The CLI fork supports `--list-keys`, `--key` and `--pin-stdin` for this Quick Action.
+- The Intel Quick Action validates the certificate output and the resulting PDF because the Intel jpackage launcher can return a signal after PKCS#11 cleanup under Rosetta.
+- A qualified timestamp is a property of the TSA response. For legal use, verify the TSA service in the EU Trusted List.
+- You can pass options to signer directly, e.g.:
+
+```bash
+scripts/macos-automation/autogram-cli-sign.sh --driver eid --pdfa "/path/to/file.pdf"
+```
+
+For a deterministic I.CA workflow, pass the driver explicitly:
+
+```bash
+scripts/macos-automation/autogram-cli-sign.sh --driver secure_store "/path/to/file.pdf"
+```
+
+## Project Findings and Troubleshooting
+
+This section records the findings from the macOS CLI and Finder Quick Action integration. Keep it updated when the signing path or packaged application changes.
+
+### 2026-08-06: I.CA SecureStore on Apple Silicon
+
+- The installed I.CA SecureStore PKCS#11 library is Intel-only: `/usr/local/lib/pkcs11/libICASecureStorePkcs11.dylib`.
+- An arm64 Java process cannot load that library. The characteristic error contains `incompatible architecture (have 'x86_64', need 'arm64')`.
+- The working configuration is the Intel Autogram build executed through Rosetta. The Quick Action detects this requirement and selects `$HOME/Applications/Autogram Intel GUI.app`.
+- Do not replace the Intel-only driver with an arm64 assumption. First check both the application and PKCS#11 library architecture with `lipo -verify_arch`.
+
+### 2026-08-06: Intel CLI exit status under Rosetta
+
+- After SunPKCS#11 is loaded, the Intel jpackage runtime can abort during native cleanup. The process may return status `137` even when the signature and output file were completed.
+- `AppStarter` flushes CLI output and terminates the short-lived Intel process after the signing work has finished. This avoids the native cleanup crash.
+- The Quick Action must therefore verify the output artifact instead of treating a non-zero process status as conclusive failure.
+- A successful PDF must be a real PDF: it starts with `%PDF-` and contains `%%EOF` near the end. A file starting with `PK` is an ASiC ZIP and must not be accepted as a PDF.
+
+### 2026-08-06: PAdES Baseline T routing
+
+- `SigningJob.getParametersForFile` originally routed only `PAdES_BASELINE_B` to `SigningParameters.buildForPDF`.
+- `PAdES_BASELINE_T` fell through to the ASiC XAdES fallback, producing an ASiC ZIP with a `.pdf` filename when the Quick Action requested a timestamped PDF.
+- `UserSettings.shouldSignPDFAsPades()` also recognized only `PAdES_BASELINE_B`, which could select the wrong output path for Baseline T.
+- The source fix must cover both places:
+  - route `PAdES_BASELINE_T` to `buildForPDF`;
+  - treat `PAdES_BASELINE_T` as PAdES in `shouldSignPDFAsPades()`.
+- The Quick Action passes `--pdf-level PAdES_BASELINE_T` and `--tsa-server http://timestamp.sectigo.com/qualified`.
+- Regression tests are in `SigningJobTests`: one checks the PAdES job form and one checks the output classification in `UserSettings`.
+
+### 2026-08-06: Packaged JAR class dependencies
+
+- Java enum `switch` statements generate synthetic companion classes. For `SigningJob`, the enum mapping is stored in `SigningJob$1.class`.
+- Updating only `SigningJob.class` inside an already packaged `autogram.jar` is insufficient. The old `SigningJob$1.class` can continue routing `PAdES_BASELINE_T` to ASiC even though the source and main class look fixed.
+- When patching a packaged application, copy every changed class and its generated companion classes, then re-sign the app. At minimum, verify:
+
+```bash
+jar tf "$HOME/Applications/Autogram Intel GUI.app/Contents/app/autogram.jar" \
+  | grep -E 'SigningJob(\$1)?\.class'
+
+codesign --verify --deep --strict "$HOME/Applications/Autogram Intel GUI.app"
+```
+
+- Use `javap` on the packaged `SigningJob$1` to confirm that `PAdES_BASELINE_T` is present in the enum mapping. Source tests alone do not prove that the packaged JAR was updated correctly.
+
+### Quick Action implementation rules
+
+- Automator provides a restricted `PATH`. Do not depend on developer tools such as `rg` in the Quick Action. Use system paths for tools such as `/usr/bin/grep`, `/usr/bin/head` and `/usr/bin/tail`.
+- Keep certificate store, certificate selection and PIN entry in macOS dialogs. The signing operation itself must remain CLI-based and must not open the Autogram GUI or Terminal UI.
+- For multiple selected files, process each PDF separately and create a distinct target using `<name>_signed.pdf`, followed by numbered variants when necessary.
+- If the output validation fails, show the captured CLI details and exit cleanly after the alert. Returning another non-zero status causes Automator to display a second empty generic error dialog.
+- Never report success only from the CLI status. Confirm the expected output path and inspect the file header when diagnosing a signing report.
+
+### Verification checklist before handing over a change
+
+1. Run the focused regression tests for PAdES Baseline T.
+2. Run the full Maven test suite with `./mvnw -q -Psystem-jdk test`.
+3. Run `bash -n` for both macOS automation scripts.
+4. Validate the installed workflow with `plutil -lint`.
+5. Confirm all changed main and synthetic classes are in the packaged JAR.
+6. Re-sign and verify the macOS app with `codesign --verify --deep --strict`.
+7. Test with a fresh source PDF. If prior outputs exist, expect a numbered output such as `_signed (2).pdf`.
+8. Do not use an earlier output that begins with `PK`; it is an ASiC container despite the `.pdf` extension.

--- a/run.sh
+++ b/run.sh
@@ -6,8 +6,9 @@ export MAVEN_OPTS="--enable-native-access=ALL-UNNAMED"
 # Clean compile and copy dependencies (clean avoids stale class files)
 ./mvnw clean compile dependency:copy-dependencies -Psystem-jdk -DskipTests
 
-# Get absolute path to icon
-ICON_PATH="/Users/Magneto/CascadeProjects/autogram-macOS/src/main/resources/digital/slovensko/autogram/ui/gui/Autogram.png"
+# Get the repository path and absolute path to the icon
+REPO_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+ICON_PATH="${REPO_DIR}/src/main/resources/digital/slovensko/autogram/ui/gui/Autogram.png"
 
 # Run the application with all necessary JVM module access flags
 # Clean line endings and no trailing spaces after backslashes are critical

--- a/scripts/macos-automation/autogram-cli-sign.sh
+++ b/scripts/macos-automation/autogram-cli-sign.sh
@@ -92,8 +92,8 @@ Usage:
   autogram-cli-sign.sh [options] <file-or-dir> [...]
 
 Examples:
-  autogram-cli-sign.sh "/Users/me/Documents/sample.pdf"
-  autogram-cli-sign.sh --driver eid --pdfa "/Users/me/Documents/invoice.pdf"
+  autogram-cli-sign.sh "/path/to/sample.pdf"
+  autogram-cli-sign.sh --driver eid --pdfa "/path/to/invoice.pdf"
 
 Notes:
   - Signed outputs are created by Autogram CLI defaults (e.g. *_signed).

--- a/scripts/macos-automation/autogram-cli-sign.sh
+++ b/scripts/macos-automation/autogram-cli-sign.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Optional overrides:
+#   AUTOGRAM_BIN=/path/to/AutogramApp ./autogram-cli-sign.sh file1.pdf
+#   AUTOGRAM_INTEL_BIN=/path/to/Intel/AutogramApp ./autogram-cli-sign.sh --driver secure_store file1.pdf
+resolve_autogram_bin() {
+  local candidates=(
+    "${AUTOGRAM_BIN:-}"
+    "/Applications/Autogram.app/Contents/MacOS/AutogramApp"
+    "$HOME/Applications/Autogram.app/Contents/MacOS/AutogramApp"
+    "$(cd "$(dirname "$0")/../.." && pwd)/target/app-image/Autogram.app/Contents/MacOS/AutogramApp"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+resolve_intel_autogram_bin() {
+  local candidates=(
+    "${AUTOGRAM_INTEL_BIN:-}"
+    "${AUTOGRAM_BIN:-}"
+    "$HOME/Applications/Autogram Intel GUI.app/Contents/MacOS/AutogramApp"
+    "$HOME/Applications/Autogram Intel.app/Contents/MacOS/AutogramApp"
+    "/Applications/Autogram Intel.app/Contents/MacOS/AutogramApp"
+    "$HOME/Applications/Autogram-intel.app/Contents/MacOS/AutogramApp"
+    "/Applications/Autogram-intel.app/Contents/MacOS/AutogramApp"
+  )
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -n "$candidate" && -x "$candidate" ]] && lipo -verify_arch x86_64 "$candidate" >/dev/null 2>&1; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+secure_store_driver_path() {
+  printf '%s\n' "/usr/local/lib/pkcs11/libICASecureStorePkcs11.dylib"
+}
+
+secure_store_requires_intel_autogram() {
+  [[ "$(uname -m)" == "arm64" ]] || return 1
+
+  local driver_path
+  driver_path="$(secure_store_driver_path)"
+  [[ -f "$driver_path" ]] || return 1
+
+  ! lipo -verify_arch arm64 "$driver_path" >/dev/null 2>&1
+}
+
+should_use_intel_autogram() {
+  local requested_driver="${1:-}"
+
+  [[ "$(uname -m)" == "arm64" ]] || return 1
+
+  if [[ "$requested_driver" == "secure_store" ]]; then
+    secure_store_requires_intel_autogram
+    return $?
+  fi
+
+  [[ -z "$requested_driver" ]] && secure_store_requires_intel_autogram
+}
+
+run_autogram() {
+  local app_bin="$1"
+  shift
+
+  if [[ "$(uname -m)" == "arm64" ]] && lipo -verify_arch x86_64 "$app_bin" >/dev/null 2>&1 \
+    && ! lipo -verify_arch arm64 "$app_bin" >/dev/null 2>&1; then
+    echo "Using Intel Autogram through Rosetta: $app_bin" >&2
+    /usr/bin/arch -x86_64 "$app_bin" "$@"
+    return
+  fi
+
+  "$app_bin" "$@"
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  autogram-cli-sign.sh [options] <file-or-dir> [...]
+
+Examples:
+  autogram-cli-sign.sh "/Users/me/Documents/sample.pdf"
+  autogram-cli-sign.sh --driver eid --pdfa "/Users/me/Documents/invoice.pdf"
+
+Notes:
+  - Signed outputs are created by Autogram CLI defaults (e.g. *_signed).
+  - Use --key and --pin-stdin for non-interactive signing.
+  - On Apple Silicon, Intel-only I.CA SecureStore needs an Intel Autogram build through Rosetta.
+  - Common forwarded options include:
+      --driver, --key, --target, --pdf-level, --slot-id, --keystore, --tsa-server, --pkcs11-driver-path
+      --pin-stdin, --list-keys, --pdfa, --plain-xml, --en319132, --force, --parents
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+declare -a common_opts=()
+declare -a sources=()
+requested_driver=""
+list_keys_requested=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --driver|--key|--target|--pdf-level|--slot-id|--keystore|--tsa-server|--pkcs11-driver-path)
+      if [[ $# -lt 2 ]]; then
+        echo "Missing value for option: $1"
+        exit 1
+      fi
+      common_opts+=("$1" "${2:-}")
+      if [[ "$1" == "--driver" ]]; then
+        requested_driver="${2:-}"
+      fi
+      shift 2
+      ;;
+    --pin-stdin|--list-keys|--pdfa|--plain-xml|--en319132|--force|--parents)
+      common_opts+=("$1")
+      [[ "$1" == "--list-keys" ]] && list_keys_requested=1
+      shift
+      ;;
+    -*)
+      echo "Unsupported option: $1"
+      usage
+      exit 1
+      ;;
+    *)
+      sources+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#sources[@]} -eq 0 && "$list_keys_requested" -eq 0 ]]; then
+  echo "No source file or directory provided."
+  usage
+  exit 1
+fi
+
+AUTOGRAM_APP_BIN="$(resolve_autogram_bin || true)"
+if should_use_intel_autogram "$requested_driver"; then
+  INTEL_AUTOGRAM_APP_BIN="$(resolve_intel_autogram_bin || true)"
+  if [[ -z "$INTEL_AUTOGRAM_APP_BIN" ]]; then
+    echo "Intel Autogram is required for the installed I.CA SecureStore driver."
+    echo "The driver is x86_64-only, while this Mac runs on Apple Silicon."
+    echo "Install the official Intel Autogram package or set AUTOGRAM_INTEL_BIN explicitly."
+    echo "Expected Intel app: \$HOME/Applications/Autogram Intel GUI.app/Contents/MacOS/AutogramApp"
+    exit 1
+  fi
+  AUTOGRAM_APP_BIN="$INTEL_AUTOGRAM_APP_BIN"
+fi
+
+if [[ -z "$AUTOGRAM_APP_BIN" ]]; then
+  echo "Autogram executable not found."
+  echo "Expected one of:"
+  echo "  /Applications/Autogram.app/Contents/MacOS/AutogramApp"
+  echo "  \$HOME/Applications/Autogram.app/Contents/MacOS/AutogramApp"
+  echo "  <repo>/target/app-image/Autogram.app/Contents/MacOS/AutogramApp"
+  echo "Or set AUTOGRAM_BIN explicitly."
+  exit 1
+fi
+
+if [[ "$list_keys_requested" -eq 1 ]]; then
+  run_autogram "$AUTOGRAM_APP_BIN" --cli "${common_opts[@]}"
+else
+  for src in "${sources[@]}"; do
+    echo "Signing: $src"
+    if [[ ${#common_opts[@]} -gt 0 ]]; then
+      run_autogram "$AUTOGRAM_APP_BIN" --cli -s "$src" "${common_opts[@]}"
+    else
+      run_autogram "$AUTOGRAM_APP_BIN" --cli -s "$src"
+    fi
+  done
+fi
+
+echo "Done."

--- a/scripts/macos-automation/autogram-finder-selection.sh
+++ b/scripts/macos-automation/autogram-finder-selection.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+QUICK_ACTION_SCRIPT="$SCRIPT_DIR/autogram-quick-action.sh"
+
+if [[ ! -x "$QUICK_ACTION_SCRIPT" ]]; then
+  echo "Quick action launcher is missing or not executable: $QUICK_ACTION_SCRIPT"
+  exit 1
+fi
+
+mapfile -t finder_selection < <(osascript <<'OSA'
+tell application "Finder"
+  if (count of selection) is 0 then
+    return ""
+  end if
+
+  set outText to ""
+  repeat with it in selection
+    set outText to outText & POSIX path of (it as alias) & linefeed
+  end repeat
+  return outText
+end tell
+OSA
+)
+
+if [[ ${#finder_selection[@]} -eq 0 || -z "${finder_selection[0]:-}" ]]; then
+  echo "No selected files/folders found in Finder."
+  exit 0
+fi
+
+"$QUICK_ACTION_SCRIPT" "${finder_selection[@]}"

--- a/scripts/macos-automation/autogram-quick-action.sh
+++ b/scripts/macos-automation/autogram-quick-action.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLI_SCRIPT="$SCRIPT_DIR/autogram-cli-sign.sh"
+QUALIFIED_TSA_URL="http://timestamp.sectigo.com/qualified"
+
+show_alert() {
+  local title="$1"
+  local message="$2"
+
+  /usr/bin/osascript - "$title" "$message" <<'OSA'
+on run argv
+  display alert (item 1 of argv) message (item 2 of argv) as warning
+end run
+OSA
+}
+
+choose_driver() {
+  /usr/bin/osascript <<'OSA'
+set driverChoices to {"I.CA SecureStore", "Občiansky preukaz (eID klient)"}
+set selectedDriver to choose from list driverChoices ¬
+  with title "Autogram: CLI podpis PDF" ¬
+  with prompt "Vyberte úložisko podpisového certifikátu." ¬
+  default items {"I.CA SecureStore"} ¬
+  OK button name "Pokračovať" ¬
+  cancel button name "Zrušiť" ¬
+  without multiple selections allowed
+
+if selectedDriver is false then
+  return "CANCELLED"
+end if
+
+return item 1 of selectedDriver
+OSA
+}
+
+choose_key_label() {
+  /usr/bin/osascript - "$@" <<'OSA'
+on run argv
+  set selectedKey to choose from list argv ¬
+    with title "Autogram: podpisový certifikát" ¬
+    with prompt "Vyberte certifikát, ktorým sa má PDF podpísať." ¬
+    OK button name "Vybrať" ¬
+    cancel button name "Zrušiť" ¬
+    without multiple selections allowed
+
+  if selectedKey is false then
+    return "CANCELLED"
+  end if
+
+  return item 1 of selectedKey
+end run
+OSA
+}
+
+ask_pin() {
+  /usr/bin/osascript <<'OSA'
+try
+  set pinDialog to display dialog "Zadajte podpisový PIN alebo heslo k certifikátu." ¬
+    with title "Autogram: podpisový PIN" ¬
+    default answer "" ¬
+    with hidden answer ¬
+    buttons {"Zrušiť", "Podpísať"} ¬
+    default button "Podpísať" ¬
+    cancel button "Zrušiť"
+  return text returned of pinDialog
+on error number -128
+  return "CANCELLED"
+end try
+OSA
+}
+
+collect_pdfs() {
+  local item
+
+  for item in "$@"; do
+    if [[ -f "$item" ]]; then
+      case "${item##*.}" in
+        [pP][dD][fF]) printf '%s\0' "$item" ;;
+      esac
+    elif [[ -d "$item" ]]; then
+      find "$item" -type f -iname '*.pdf' -print0
+    fi
+  done
+}
+
+next_signed_path() {
+  local source="$1"
+  local stem="${source%.*}"
+  local candidate="${stem}_signed.pdf"
+  local suffix=1
+
+  while [[ -e "$candidate" ]]; do
+    candidate="${stem}_signed ($suffix).pdf"
+    suffix=$((suffix + 1))
+  done
+
+  printf '%s\n' "$candidate"
+}
+
+is_valid_pdf() {
+  local path="$1"
+  [[ -s "$path" ]] || return 1
+  [[ "$(/usr/bin/head -c 5 "$path")" == "%PDF-" ]] || return 1
+  /usr/bin/tail -c 1024 "$path" | /usr/bin/grep -q '%%EOF'
+}
+
+cli_error_details() {
+  local log_file="$1"
+  local details
+
+  details="$(/usr/bin/tail -n 12 "$log_file" 2>/dev/null | /usr/bin/tr '\n' ' ' | /usr/bin/cut -c1-800)"
+  if [[ -z "$details" ]]; then
+    details="CLI neposkytlo ďalšie podrobnosti."
+  fi
+
+  printf '%s\n' "$details"
+}
+
+driver_shortname() {
+  case "$1" in
+    "I.CA SecureStore") printf '%s\n' "secure_store" ;;
+    "Občiansky preukaz (eID klient)") printf '%s\n' "eid" ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ $# -eq 0 ]]; then
+  show_alert "Autogram" "Neboli odovzdané žiadne súbory."
+  exit 0
+fi
+
+declare -a pdfs=()
+while IFS= read -r -d '' pdf; do
+  pdfs+=("$pdf")
+done < <(collect_pdfs "$@")
+
+if [[ ${#pdfs[@]} -eq 0 ]]; then
+  show_alert "Autogram" "Vo výbere sa nenašli žiadne PDF súbory."
+  exit 0
+fi
+
+driver_name="$(choose_driver)"
+if [[ "$driver_name" == "CANCELLED" || -z "$driver_name" ]]; then
+  exit 0
+fi
+
+driver_name_arg="$(driver_shortname "$driver_name" || true)"
+if [[ -z "$driver_name_arg" ]]; then
+  show_alert "Autogram" "Neznáme úložisko certifikátu: $driver_name"
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d -t autogram-quick-action)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+pin="$(ask_pin)"
+if [[ "$pin" == "CANCELLED" ]]; then
+  exit 0
+fi
+
+key_output="$tmp_dir/keys.tsv"
+key_error="$tmp_dir/keys.error"
+set +e
+printf '%s\n' "$pin" | "$CLI_SCRIPT" \
+    --driver "$driver_name_arg" \
+    --list-keys \
+    --pin-stdin > "$key_output" 2> "$key_error"
+key_status=$?
+set -e
+
+if [[ "$key_status" -ne 0 ]] && ! /usr/bin/grep -q $'^AUTOGRAM_KEY\t' "$key_output"; then
+  key_details="$(cli_error_details "$key_error")"
+  key_message="$(printf '%s\n\n%s' \
+    'Nepodarilo sa načítať podpisové certifikáty. Skontrolujte pripojené úložisko a PIN.' \
+    "$key_details")"
+  show_alert "Autogram" "$key_message"
+  exit 0
+fi
+
+declare -a key_selectors=()
+declare -a key_labels=()
+while IFS=$'\t' read -r record_type selector label; do
+  [[ "$record_type" == "AUTOGRAM_KEY" ]] || continue
+  [[ -n "$selector" ]] || continue
+  key_selectors+=("$selector")
+  key_labels+=("$label [$selector]")
+done < "$key_output"
+
+if [[ ${#key_selectors[@]} -eq 0 ]]; then
+  show_alert "Autogram" "V zvolenom úložisku sa nenašiel žiadny podpisový certifikát."
+  exit 1
+fi
+
+if [[ ${#key_selectors[@]} -eq 1 ]]; then
+  key_selector="${key_selectors[0]}"
+else
+  selected_label="$(choose_key_label "${key_labels[@]}")"
+  if [[ "$selected_label" == "CANCELLED" || -z "$selected_label" ]]; then
+    exit 0
+  fi
+
+  key_selector=""
+  for index in "${!key_labels[@]}"; do
+    if [[ "${key_labels[$index]}" == "$selected_label" ]]; then
+      key_selector="${key_selectors[$index]}"
+      break
+    fi
+  done
+
+  if [[ -z "$key_selector" ]]; then
+    show_alert "Autogram" "Nepodarilo sa vybrať podpisový certifikát."
+    exit 1
+  fi
+fi
+
+for index in "${!pdfs[@]}"; do
+  log_file="$tmp_dir/sign-$index.log"
+  target_path="$(next_signed_path "${pdfs[$index]}")"
+  set +e
+  printf '%s\n' "$pin" | "$CLI_SCRIPT" \
+      --driver "$driver_name_arg" \
+      --key "$key_selector" \
+      --pin-stdin \
+      --pdf-level PAdES_BASELINE_T \
+      --tsa-server "$QUALIFIED_TSA_URL" \
+      --target "$target_path" \
+      "${pdfs[$index]}" > "$log_file" 2>&1
+  set -e
+
+  if ! is_valid_pdf "$target_path"; then
+    sign_details="$(cli_error_details "$log_file")"
+    sign_message="$(printf 'Podpisovanie zlyhalo pri súbore: %s\n\n%s' \
+      "${pdfs[$index]}" "$sign_details")"
+    show_alert "Autogram" "$sign_message"
+    exit 0
+  fi
+done
+
+success_message="$(printf 'Podpísaných PDF: %s\nPoužitý podpis: PAdES Baseline T\nKvalifikovaná časová pečiatka: Sectigo qualified TSA' "${#pdfs[@]}")"
+show_alert "Autogram" "$success_message"

--- a/src/main/java/digital/slovensko/autogram/core/AppStarter.java
+++ b/src/main/java/digital/slovensko/autogram/core/AppStarter.java
@@ -5,8 +5,6 @@ import digital.slovensko.autogram.ui.gui.GUIApp;
 import javafx.application.Application;
 import org.apache.commons.cli.*;
 
-import org.slf4j.bridge.SLF4JBridgeHandler;
-
 import java.io.PrintWriter;
 
 public class AppStarter {
@@ -24,11 +22,17 @@ public class AppStarter {
             .addOption(null, "parents", false, "Create all parent directories for target if needed.")
             .addOption("d", "driver", true,
                     "PCKS driver name for signing. Supported values: eid, cz_eid, secure_store, monet, gemalto, keystore, custom_pkcs11 (requires valid path within pkcs11-driver-path option).")
+            .addOption(null, "key", true,
+                    "Certificate serial number or common name to use without an interactive key prompt.")
+            .addOption(null, "pin-stdin", false,
+                    "Read the signing PIN or password from standard input without an interactive prompt.")
+            .addOption(null, "list-keys", false,
+                    "List available signing certificates and exit.")
             .addOption(null, "keystore", true, "Absolute path to a keystore file that can be used for signing.")
             .addOption(null, "slot-id", true,
                     "Slot ID for PKCS11 driver. If not specified, first available slot is used.")
             .addOption(null, "pdf-level", true,
-                    "PDF signature level. Supported values: PAdES_BASELINE_B (default), XAdES_BASELINE_B, CAdES_BASELINE_B.")
+                    "PDF signature level. Supported values include PAdES_BASELINE_B and PAdES_BASELINE_T.")
             .addOption(null, "en319132", false, "Sign according to EN 319 132 or EN 319 122.")
             .addOption(null, "tsa-server", true,
                     "Url of TimeStamp Authority server that should be used for timestamping in signature level BASELINE_T. If provided, BASELINE_T signatures are made.")
@@ -40,10 +44,6 @@ public class AppStarter {
         System.setProperty("apple.awt.application.name", "Autogram");
         System.setProperty("com.apple.mrj.application.apple.menu.about.name", "Autogram");
 
-        // Suppress VeraPDF logs (uses JUL) by bridging to SLF4J
-        SLF4JBridgeHandler.removeHandlersForRootLogger();
-        SLF4JBridgeHandler.install();
-
         try {
             CommandLine cmd = new DefaultParser().parse(options, args);
 
@@ -52,7 +52,13 @@ public class AppStarter {
             } else if (cmd.hasOption("u")) {
                 printUsage();
             } else if (cmd.hasOption("c")) {
-                CliApp.start(cmd);
+                var exitCode = CliApp.start(cmd);
+                System.out.flush();
+                System.err.flush();
+                if (isIntelProcess())
+                    terminateCliProcess(exitCode);
+                else
+                    System.exit(exitCode);
             } else {
                 Application.launch(GUIApp.class, args);
             }
@@ -60,6 +66,22 @@ public class AppStarter {
             System.err.println("Unable to parse program args");
             System.err.println(e);
         }
+    }
+
+    private static void terminateCliProcess(int exitCode) {
+        // The Intel jpackage launcher aborts in native cleanup after SunPKCS11 is loaded.
+        // CLI output and files are flushed before terminating the short-lived process.
+        try {
+            new ProcessBuilder("/bin/kill", "-KILL", Long.toString(ProcessHandle.current().pid())).start();
+            while (true)
+                Thread.onSpinWait();
+        } catch (java.io.IOException e) {
+            Runtime.getRuntime().halt(exitCode);
+        }
+    }
+
+    private static boolean isIntelProcess() {
+        return "x86_64".equals(System.getProperty("os.arch"));
     }
 
     public static void printHelp() {

--- a/src/main/java/digital/slovensko/autogram/core/Autogram.java
+++ b/src/main/java/digital/slovensko/autogram/core/Autogram.java
@@ -12,6 +12,7 @@ import digital.slovensko.autogram.util.PDFUtils;
 import eu.europa.esig.dss.model.DSSException;
 import eu.europa.esig.dss.pdfa.PDFAStructureValidator;
 import eu.europa.esig.dss.spi.x509.tsp.TSPSource;
+import eu.europa.esig.dss.token.DSSPrivateKeyEntry;
 
 import java.io.File;
 import java.util.List;
@@ -293,6 +294,12 @@ public class Autogram {
 
     public List<TokenDriver> getAvailableDrivers() {
         return settings.getDriverDetector().getAvailableDrivers();
+    }
+
+    public List<DSSPrivateKeyEntry> getSigningKeys(TokenDriver driver) {
+        // Intel PKCS#11 cleanup crashes under Rosetta before the CLI process exits.
+        var token = driver.createToken(passwordManager, settings);
+        return token.getKeys();
     }
 
     public boolean isPlainXmlEnabled() {

--- a/src/main/java/digital/slovensko/autogram/core/SigningJob.java
+++ b/src/main/java/digital/slovensko/autogram/core/SigningJob.java
@@ -209,6 +209,7 @@ public class SigningJob {
 
         if (isPDF(document.getMimeType())) switch (signatureType) {
             case PAdES_BASELINE_B:
+            case PAdES_BASELINE_T:
                 return SigningParameters.buildForPDF(document, checkPDFACompliance, isEn319132, tspSource);
             case XAdES_BASELINE_B:
                 return SigningParameters.buildForASiCWithXAdES(document, checkPDFACompliance, isEn319132, tspSource, plainXmlEnabled);

--- a/src/main/java/digital/slovensko/autogram/core/UserSettings.java
+++ b/src/main/java/digital/slovensko/autogram/core/UserSettings.java
@@ -226,7 +226,8 @@ public class UserSettings implements PasswordManagerSettings, SignatureTokenSett
     }
 
     public boolean shouldSignPDFAsPades() {
-        return signatureLevel == SignatureLevel.PAdES_BASELINE_B;
+        return signatureLevel == SignatureLevel.PAdES_BASELINE_B
+                || signatureLevel == SignatureLevel.PAdES_BASELINE_T;
     }
 
     public void setSignatureLevel(SignatureLevel signatureLevel) {

--- a/src/main/java/digital/slovensko/autogram/ui/cli/CliApp.java
+++ b/src/main/java/digital/slovensko/autogram/ui/cli/CliApp.java
@@ -7,18 +7,25 @@ import digital.slovensko.autogram.core.errors.AutogramException;
 import digital.slovensko.autogram.core.errors.SourceDoesNotExistException;
 import digital.slovensko.autogram.core.errors.SourceNotDefinedException;
 import digital.slovensko.autogram.ui.SaveFileResponder;
+import eu.europa.esig.dss.model.DSSException;
 import org.apache.commons.cli.CommandLine;
 
 import java.io.File;
 import java.util.Arrays;
 
 public class CliApp {
-    public static void start(CommandLine cmd) {
+    public static int start(CommandLine cmd) {
         Autogram autogram = null;
         try {
             var settings = CliSettings.fromCmd(cmd);
             var ui = new CliUI(settings);
             autogram = new Autogram(ui, settings);
+
+            if (settings.isListKeys()) {
+                var driver = ui.pickTokenDriver(autogram.getAvailableDrivers());
+                ui.printSigningKeys(autogram.getSigningKeys(driver));
+                return 0;
+            }
 
             if (settings.getSource() == null)
                 throw new SourceNotDefinedException();
@@ -47,13 +54,28 @@ public class CliApp {
 
             ui.setJobsCount(jobs.size());
             jobs.forEach(autogram::sign);
+            return 0;
 
         } catch (AutogramException e) {
             System.err.println(CliUI.parseError(e));
-
+            return 1;
+        } catch (DSSException e) {
+            return reportFailure(AutogramException.createFromDSSException(e));
+        } catch (Exception e) {
+            return reportFailure(e);
         } finally {
             if (autogram != null)
                 autogram.shutdown();
         }
     }
+
+    static int reportFailure(Exception e) {
+        if (e instanceof AutogramException autogramException) {
+            System.err.println(CliUI.parseError(autogramException));
+        } else {
+            e.printStackTrace(System.err);
+        }
+        return 1;
+    }
+
 }

--- a/src/main/java/digital/slovensko/autogram/ui/cli/CliKeySelector.java
+++ b/src/main/java/digital/slovensko/autogram/ui/cli/CliKeySelector.java
@@ -1,0 +1,32 @@
+package digital.slovensko.autogram.ui.cli;
+
+import digital.slovensko.autogram.util.DSSUtils;
+import eu.europa.esig.dss.token.DSSPrivateKeyEntry;
+
+public final class CliKeySelector {
+    private CliKeySelector() {
+    }
+
+    public static boolean matches(DSSPrivateKeyEntry key, String selector) {
+        var certificate = key.getCertificate();
+        var serial = certificate.getSerialNumber().toString();
+        var commonName = DSSUtils.parseCN(certificate.getSubject().getRFC2253());
+        return matches(serial, commonName, selector);
+    }
+
+    public static boolean matches(String serial, String commonName, String selector) {
+        if (selector == null || selector.isBlank())
+            return false;
+
+        var normalizedSelector = selector.trim();
+        return normalizedSelector.equals(serial) || normalizedSelector.equals(commonName);
+    }
+
+    public static String serial(DSSPrivateKeyEntry key) {
+        return key.getCertificate().getSerialNumber().toString();
+    }
+
+    public static String commonName(DSSPrivateKeyEntry key) {
+        return DSSUtils.parseCN(key.getCertificate().getSubject().getRFC2253());
+    }
+}

--- a/src/main/java/digital/slovensko/autogram/ui/cli/CliSettings.java
+++ b/src/main/java/digital/slovensko/autogram/ui/cli/CliSettings.java
@@ -16,6 +16,9 @@ public class CliSettings extends UserSettings {
     private File source;
     private boolean isForce;
     private boolean shouldMakeParentDirectories;
+    private String keySelector;
+    private boolean pinFromStdin;
+    private boolean listKeys;
 
     public static CliSettings fromCmd(CommandLine cmd) {
         var settings = new CliSettings();
@@ -23,6 +26,9 @@ public class CliSettings extends UserSettings {
         settings.setSource(getValidSource(cmd.getOptionValue("s")));
         settings.setTarget(cmd.getOptionValue("t"));
         settings.setDriver(cmd.getOptionValue("d"));
+        settings.setKeySelector(cmd.getOptionValue("key"));
+        settings.setPinFromStdin(cmd.hasOption("pin-stdin"));
+        settings.setListKeys(cmd.hasOption("list-keys"));
         settings.setCustomKeystorePath(cmd.getOptionValue("keystore", ""));
         settings.setDriverSlotIndex("default", getValidSlotIndex(cmd.getOptionValue("slot-id")));
         settings.setForce(cmd.hasOption("f"));
@@ -74,6 +80,30 @@ public class CliSettings extends UserSettings {
 
     public boolean shouldMakeParentDirectories() {
         return shouldMakeParentDirectories;
+    }
+
+    public String getKeySelector() {
+        return keySelector;
+    }
+
+    private void setKeySelector(String value) {
+        keySelector = value;
+    }
+
+    public boolean isPinFromStdin() {
+        return pinFromStdin;
+    }
+
+    private void setPinFromStdin(boolean value) {
+        pinFromStdin = value;
+    }
+
+    public boolean isListKeys() {
+        return listKeys;
+    }
+
+    private void setListKeys(boolean value) {
+        listKeys = value;
     }
 
     private static File getValidSource(String sourcePath) throws SourceDoesNotExistException {

--- a/src/main/java/digital/slovensko/autogram/ui/cli/CliUI.java
+++ b/src/main/java/digital/slovensko/autogram/ui/cli/CliUI.java
@@ -40,6 +40,9 @@ import digital.slovensko.autogram.ui.gui.IgnorableException;
 import eu.europa.esig.dss.token.DSSPrivateKeyEntry;
 
 import java.io.File;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -51,6 +54,8 @@ public class CliUI implements UI {
     SigningKey activeKey;
     int nJobsSigned = 1;
     int nJobsTotal = 0;
+    private final BufferedReader stdin = new BufferedReader(new InputStreamReader(System.in));
+    private char[] stdinSecret;
 
     public CliUI(CliSettings settings) {
         this.settings = settings;
@@ -91,20 +96,26 @@ public class CliUI implements UI {
 
     @Override
     public void pickTokenDriverAndThen(List<TokenDriver> drivers, Consumer<TokenDriver> callback, Runnable onCancel) {
-        TokenDriver pickedDriver;
+        callback.accept(pickTokenDriver(drivers));
+    }
+
+    public TokenDriver pickTokenDriver(List<TokenDriver> drivers) {
         if (drivers.isEmpty()) {
             showError(new NoDriversDetectedException());
-            return;
+            throw new NoDriversDetectedException();
 
         } else if (drivers.size() == 1) {
-            pickedDriver = drivers.get(0);
+            return drivers.get(0);
 
         } else if (settings.getDefaultDriver() != null) {
-            var driver = drivers.stream().filter(d -> d.getShortname().equals(settings.getDefaultDriver())).findFirst();
+            var driver = drivers.stream()
+                    .filter(d -> d.getShortname().equals(settings.getDefaultDriver())
+                            || d.getName().equals(settings.getDefaultDriver()))
+                    .findFirst();
             if (driver.isEmpty())
                 throw new NoDriversDetectedException();
 
-            pickedDriver = driver.get();
+            return driver.get();
 
         } else {
             var i = new AtomicInteger(1);
@@ -114,15 +125,26 @@ public class CliUI implements UI {
                 System.out.println(driver.getName());
                 i.addAndGet(1);
             });
-            pickedDriver = drivers.get(CliUtils.readInteger() - 1);
+            return drivers.get(CliUtils.readInteger() - 1);
         }
-        callback.accept(pickedDriver);
     }
 
     @Override
     public void pickKeyAndThen(List<DSSPrivateKeyEntry> keys, TokenDriver driver, Consumer<DSSPrivateKeyEntry> callback) {
         if (keys.isEmpty()) {
             showError(new NoKeysDetectedException(driver.getNoKeysHelperText()));
+            return;
+        }
+
+        if (settings.getKeySelector() != null) {
+            var matchingKeys = keys.stream()
+                    .filter(key -> CliKeySelector.matches(key, settings.getKeySelector()))
+                    .toList();
+            if (matchingKeys.size() != 1) {
+                showError(new NoKeysDetectedException(driver.getNoKeysHelperText()));
+                return;
+            }
+            callback.accept(matchingKeys.get(0));
             return;
         }
 
@@ -233,6 +255,13 @@ public class CliUI implements UI {
         throw exception;
     }
 
+    public void printSigningKeys(List<DSSPrivateKeyEntry> keys) {
+        for (var key : keys) {
+            System.out.println("AUTOGRAM_KEY\t" + CliKeySelector.serial(key) + "\t"
+                    + CliKeySelector.commonName(key));
+        }
+    }
+
     public static String parseError(AutogramException e) {
         if (e instanceof FunctionCanceledException) {
             return "No security code entered";
@@ -293,11 +322,27 @@ public class CliUI implements UI {
 
     @Override
     public char[] getKeystorePassword() {
-        return System.console().readPassword("Enter keystore password (hidden): ");
+        return readSecret("Enter keystore password (hidden): ");
     }
 
     public char[] getContextSpecificPassword() {
-        return System.console().readPassword("Enter key password (hidden): ");
+        return readSecret("Enter key password (hidden): ");
+    }
+
+    private char[] readSecret(String prompt) {
+        if (!settings.isPinFromStdin())
+            return System.console().readPassword(prompt);
+
+        if (stdinSecret != null)
+            return stdinSecret.clone();
+
+        try {
+            var line = stdin.readLine();
+            stdinSecret = line == null ? null : line.toCharArray();
+            return stdinSecret == null ? null : stdinSecret.clone();
+        } catch (IOException e) {
+            return null;
+        }
     }
 
     @Override

--- a/src/test/java/digital/slovensko/autogram/SigningJobTests.java
+++ b/src/test/java/digital/slovensko/autogram/SigningJobTests.java
@@ -1,12 +1,15 @@
 package digital.slovensko.autogram;
 
 import digital.slovensko.autogram.core.SigningJob;
+import digital.slovensko.autogram.core.UserSettings;
 import digital.slovensko.autogram.server.dto.Document;
 import digital.slovensko.autogram.server.dto.ServerSigningParameters;
 import digital.slovensko.autogram.server.dto.SignRequestBody;
 import digital.slovensko.autogram.server.errors.RequestValidationException;
 import eu.europa.esig.dss.enumerations.ASiCContainerType;
 import eu.europa.esig.dss.enumerations.SignatureLevel;
+import eu.europa.esig.dss.enumerations.SignatureForm;
+import eu.europa.esig.dss.spi.x509.tsp.CompositeTSPSource;
 
 import org.junit.jupiter.api.Test;
 
@@ -49,5 +52,23 @@ public class SigningJobTests {
         var signRequestBody = new SignRequestBody(new Document(content), ssParams, "application/xml;base64");
         assertDoesNotThrow(() ->
                 SigningJob.buildFromRequest(signRequestBody.getDocument(), signRequestBody.getParameters(null, true), null));
+    }
+
+    @Test
+    void treatsPadesBaselineTAsPdfSigningJob() {
+        var file = new java.io.File("src/test/resources/digital/slovensko/autogram/sample.pdf");
+        var job = SigningJob.buildFromFile(file, null, false, SignatureLevel.PAdES_BASELINE_T,
+                false, new CompositeTSPSource(), true);
+
+        assertEquals(SignatureForm.PAdES, job.getParameters().getSignatureType());
+        assertEquals(SignatureLevel.PAdES_BASELINE_T, job.getParameters().getLevel());
+    }
+
+    @Test
+    void treatsPadesBaselineTAsPadesInUserSettings() {
+        var settings = new UserSettings();
+        settings.setSignatureLevel(SignatureLevel.PAdES_BASELINE_T);
+
+        assertTrue(settings.shouldSignPDFAsPades());
     }
 }

--- a/src/test/java/digital/slovensko/autogram/ui/cli/CliHeadlessSettingsTest.java
+++ b/src/test/java/digital/slovensko/autogram/ui/cli/CliHeadlessSettingsTest.java
@@ -1,0 +1,59 @@
+package digital.slovensko.autogram.ui.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.Options;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CliHeadlessSettingsTest {
+    @Test
+    void parsesHeadlessCertificateAndPinOptions() throws Exception {
+        var settings = CliSettings.fromCmd(parse(
+                "--driver", "secure_store",
+                "--key", "123456789",
+                "--pin-stdin",
+                "--list-keys"));
+
+        assertEquals("secure_store", settings.getDefaultDriver());
+        assertEquals("123456789", settings.getKeySelector());
+        assertTrue(settings.isPinFromStdin());
+        assertTrue(settings.isListKeys());
+    }
+
+    @Test
+    void matchesCertificateBySerialOrCommonName() {
+        assertTrue(CliKeySelector.matches("123456789", "Majo Cuprik", "123456789"));
+        assertTrue(CliKeySelector.matches("123456789", "Majo Cuprik", "Majo Cuprik"));
+        assertFalse(CliKeySelector.matches("123456789", "Majo Cuprik", "Someone Else"));
+    }
+
+    @Test
+    void reportsUnexpectedCliFailuresWithNonZeroStatus() {
+        var originalError = System.err;
+        var capturedError = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(capturedError));
+        try {
+            assertEquals(1, CliApp.reportFailure(new IllegalStateException("test failure")));
+        } finally {
+            System.setErr(originalError);
+        }
+        assertTrue(capturedError.toString(StandardCharsets.UTF_8).contains("test failure"));
+    }
+
+    private static CommandLine parse(String... args) throws Exception {
+        var options = new Options()
+                .addOption("d", "driver", true, "")
+                .addOption(null, "key", true, "")
+                .addOption(null, "pin-stdin", false, "")
+                .addOption(null, "list-keys", false, "");
+        return new DefaultParser().parse(options, args);
+    }
+}


### PR DESCRIPTION
## Summary
Add a macOS Finder Quick Action that signs one or more selected PDF files through Autogram CLI without opening the Autogram GUI or a Terminal window.

## Finder workflow
- Install the CLI-capable Autogram application and the required token or card driver.
- Create an Automator **Quick Action**, not a macOS Shortcut.
- Configure it to receive `files or folders` in `Finder` and pass input as shell arguments.
- Choose the certificate store and certificate through macOS dialogs.
- Enter the PIN through a hidden macOS dialog.
- The action processes multiple selected PDFs and saves new files beside the originals.

## Signing behavior
- PAdES Baseline T is enabled by default.
- A qualified TSA endpoint is configured by default. The provider qualification must be verified in the applicable trusted list before regulated use.
- On Apple Silicon, the launcher detects Intel-only PKCS#11 providers and uses an Intel Autogram build through Rosetta when available.
- Original files are preserved and output names are numbered when needed.

## Documentation
- The English and Slovak README files document Finder, Automator, requirements, installation, Apple Silicon, and troubleshooting.
- `docs/macos-cli-automation.md` records the architecture, packaged-JAR, PAdES T, and Quick Action findings.

## Verification
- Headless CLI and Quick Action tests pass on the synchronized upstream v2.7.5 base.
- Changed public files were checked for personal paths, credentials, private keys, and client data.

Base branch: `codex/upstream-sync-2026-08`. Merge the upstream sync PR first, then this feature PR.